### PR TITLE
Add PostgreSQL 9.6.6 as a service.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,15 @@ services:
     restart: on-failure
     volumes:
       - ports_mirror:/ports-mirror
+  postgres:
+    image: postgres:9.6
+    restart: on-failure
+    environment:
+      POSTGRES_USER: "baron"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
   smtp:
     image: mwader/postfix-relay
     restart: on-failure
@@ -53,3 +62,4 @@ services:
 volumes:
   gerrit_data:
   ports_mirror:
+  postgres_data:


### PR DESCRIPTION
This will be configured as a service for more than one container.

This setting sets up the admin user as user 'baron'. It does not set an initial password for this user. This should be done afterwards.
I have chosen to expose the database port to maui itself. This will make it easier to tunnel the database through ssh, as well as to make (manual) changes to various databases without having to enter into a container.