### PR TITLE
Update Trac image and add to docker-compose

### DIFF
--- a/data/router/trac.conf
+++ b/data/router/trac.conf
@@ -1,0 +1,26 @@
+
+# Trac
+
+server {
+	listen 80;
+
+	server_name dev.haiku-os.org;
+	access_log off;
+	error_log off;
+	return  301 https://$server_name$request_uri;
+}
+
+server {
+	listen 443 ssl http2;
+
+	server_name dev.haiku-os.org;
+	client_max_body_size 100m;
+	ssl_certificate /etc/letsencrypt/live/dev.haiku-os.org/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/dev.haiku-os.org/privkey.pem;
+	location / {
+		proxy_bind  $server_addr;
+		proxy_pass  http://infrastructure_trac_1:80;
+		proxy_set_header  X-Forwarded-For $remote_addr;
+		proxy_set_header  Host $host;
+	}
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,14 @@ services:
     restart: on-failure
     environment:
       - POSTFIX_myhostname=maui.haiku-os.org
+  trac:
+    image: nielx/trac
+    volumes:
+      - trac_data:/var/trac
+    depends_on:
+      - postgres
 volumes:
   gerrit_data:
   ports_mirror:
   postgres_data:
+  trac_data:

--- a/docker/trac/Dockerfile
+++ b/docker/trac/Dockerfile
@@ -9,7 +9,10 @@ WORKDIR /app
 ADD requirements.txt /app
 
 # Install the requirements
-RUN apk update && apk add git py-psycopg2
+RUN apk update && \
+    apk add --virtual build-deps gcc python-dev musl-dev && \
+    apk add git postgresql-dev
+
 RUN pip install -r requirements.txt
 
 CMD /usr/local/bin/tracd -b 0.0.0.0 -p 80 -s /var/trac/dev.haiku-os.org

--- a/docker/trac/requirements.txt
+++ b/docker/trac/requirements.txt
@@ -4,7 +4,7 @@ Babel==0.9.6
 docutils==0.13.1
 Genshi==0.7
 packaging==16.8
-# psycopg2==2.6.2 ### installed in the Dockerfile
+psycopg2==2.6.2
 Pygments==2.2.0
 pyparsing==2.1.10
 pytz==2016.10

--- a/tools/cert-renew
+++ b/tools/cert-renew
@@ -8,7 +8,7 @@
 # TODO: Test each certificate for validity? If no certs
 # expire soon, don't bring down router container?
 
-DOMAINS="review.haiku-os.org cgit.haiku-os.org git.haiku-os.org haiku-os.org api.haiku-os.org userguide.haiku-os.org ports-mirror.haiku-os.org"
+DOMAINS="review.haiku-os.org cgit.haiku-os.org dev.haiku-os.org git.haiku-os.org haiku-os.org api.haiku-os.org userguide.haiku-os.org ports-mirror.haiku-os.org dev.haiku-os.org"
 LOG="/var/log/letsencrypt.log"
 CONTEXT="/root/infrastructure"
 

--- a/tools/fake-cert
+++ b/tools/fake-cert
@@ -9,7 +9,7 @@
 # To regenerate fakecerts, rm -rf /etc/letsencrypt/live/*
 
 CERT_ROOT="/etc/letsencrypt/live"
-DOMAINS="review.haiku-os.org cgit.haiku-os.org git.haiku-os.org haiku-os.org api.haiku-os.org userguide.haiku-os.org ports-mirror.haiku-os.org"
+DOMAINS="review.haiku-os.org cgit.haiku-os.org git.haiku-os.org haiku-os.org api.haiku-os.org userguide.haiku-os.org ports-mirror.haiku-os.org dev.haiku-os.org"
 mkdir -p $CERT_ROOT
 for i in $DOMAINS; do
 	if [ -d $CERT_ROOT/$i ]; then


### PR DESCRIPTION
The Trac image is updated to have a proper psycopg2 module (see the notes in the commit for more details). 

This also adds the Trac service to the router.

Ideally, I'd like to set it up on maui as a testing/staging environment (dev-next.haiku-os.org). But I imagine we do this manually. I am also not familiar with the letsencrypt daemon.