### PR TITLE
Add a container that can run the userguide application.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,14 @@ services:
     depends_on:
       - postgres
       - smtp
+  userguide:
+    image: nielx/userguide
+    restart: on-failure
+    volumes:
+      - userguide_data:/var/userguide:z
+    depends_on:
+      - postgres
+      - smtp
   buildbot:
     image: buildbot/buildbot-master:v1.1.0
     hostname: buildbot
@@ -95,4 +103,5 @@ volumes:
   pootle_data:
   ports_mirror:
   postgres_data:
+  userguide_data:
   trac_data:

--- a/docker/userguide/Dockerfile
+++ b/docker/userguide/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7.2-apache
+
+RUN apt-get update && apt-get install -y libpq-dev git && docker-php-ext-install pdo pdo_pgsql
+
+ENV APACHE_DOCUMENT_ROOT /var/userguide/app/userguide
+
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+WORKDIR /var/userguide/

--- a/docker/userguide/README.md
+++ b/docker/userguide/README.md
@@ -1,0 +1,14 @@
+# Userguide application container
+
+This is a custom container that contains php-apache with pdo and pdo_pgsql
+modules installed.
+
+On the actual instance, it is good to use a persistent volume mounted at
+/var/userguide.
+
+The volume should contain the following:
+ - A checkout of https://github.com/haiku/userguide-translator as /var/userguide/app
+ - A filled config.php at /var/userguide/app/userguide/inc/config.php
+
+To update the userguide tool, execute:
+    `docker exec -it <CONTAINER_ID> git pull /var/userguide/app`


### PR DESCRIPTION
Notes:

 * I picked php-apache over php-fpm, because the latter would either
   require an inefficient setup to serve static files, or it would
   require an elaborate configuration to serve the static files through
   nginx.
 * I also decided that the container will merely contain the elements to
   run the application, but that the application itself is part of the
   persistent storage. This is also mostly due to practical
   considerations, as otherwise the source_docs and export directories
   would need to be linked to a persistent volume. This just feels more
   clean.