### PR TITLE
Add a container that can run the userguide application, using a

### DIFF
--- a/data/router/i18n.conf
+++ b/data/router/i18n.conf
@@ -1,0 +1,35 @@
+
+# i18n: Pootle and the Userguide translator
+
+server {
+	listen 80;
+
+	server_name i18n.haiku-os.org;
+	access_log off;
+	error_log off;
+	return  301 https://$server_name$request_uri;
+}
+
+server {
+	listen 443 ssl http2;
+
+	server_name i18n.haiku-os.org;
+	client_max_body_size 100m;
+	ssl_certificate /etc/letsencrypt/live/i18n.haiku-os.org/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/i18n.haiku-os.org/privkey.pem;
+	location / {
+		alias /static-html/i18n/;
+	}
+	location /pootle/ {
+		proxy_bind  $server_addr;
+		proxy_pass  http://infrastructure_pootle_1:80;
+		proxy_set_header  X-Forwarded-For $remote_addr;
+		proxy_set_header  Host $host;
+	}
+	location /userguide/ {
+		proxy_bind  $server_addr;
+		proxy_pass  http://infrastructure_userguide_1:80;
+		proxy_set_header  X-Forwarded-For $remote_addr;
+		proxy_set_header  Host $host;
+	}
+}

--- a/data/static-html/i18n/index.html
+++ b/data/static-html/i18n/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<link rel="shortcut icon" href="https://i18n.haiku-os.org/userguide/favicon.ico" type="image/x-icon"/>
+	<link rel="bookmark icon" href="https://i18n.haiku-os.org/userguide/favicon.ico" type="image/x-icon"/>
+	<title>Haiku Project internationalization</title>
+	<link rel="stylesheet" type="text/css" href="https://i18n.haiku-os.org/userguide/export/docs/userguide/Haiku-doc.css"/>
+</head>
+<body>
+	<div id="banner">
+		<div><span>Welcome to the Haiku internationalization site</span></div>
+	</div>
+	<div id="content">
+		<div>
+			<!-- Header -->
+			<p><a href="https://www.haiku-os.org/" target="_blank">Haiku</a> is a free and open source operating system with support for localization and translation.</p>
+
+			<!-- Information links section -->
+			<h2>Information about localization</h2>
+			<p>Listed here are links to standards and guides on how to translate the Haiku interface and documentation to your language to get you started</p>
+			<ul>
+				<li><a href="https://dev.haiku-os.org/wiki/i18n" class="printurl">i18n documentation on the wiki</a></li>
+				<li><a href="https://www.haiku-os.org/community/ml#localization" class="printurl">i18n mailing lists</a></li>
+			</ul>
+
+			<!-- Translation links section -->
+			<h2>Translation sites</h2>
+			<p>Listed here are links to the translation sites to begin translating</p>
+			<ul>
+				<li><a href="https://i18n.haiku-os.org/pootle/" class="printurl">Haiku Interface Translation</a> - GUI translation</li>
+				<li><a href="https://i18n.haiku-os.org/userguide/" class="printurl">Documentation Translation</a> - Documentation translation</li>
+			</ul>
+		</div>
+	</div>
+
+	<!-- This nonbreaking space right here raises compatibility concerns... -->
+	<div class="nav">
+		<div class="inner"><span>&nbsp;</span></div>
+	</div>
+</body>
+</html>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,14 @@ services:
     depends_on:
       - postgres
       - smtp
+  userguide:
+    image: nielx/userguide
+    restart: on-failure
+    volumes:
+      - userguide_data:/var/userguide:z
+    depends_on:
+      - postgres
+      - smtp
   buildbot:
     image: buildbot/buildbot-master:v1.1.0
     hostname: buildbot
@@ -95,4 +103,5 @@ volumes:
   pootle_data:
   ports_mirror:
   postgres_data:
+  userguide_data:
   trac_data:

--- a/docker/userguide/Dockerfile
+++ b/docker/userguide/Dockerfile
@@ -1,0 +1,9 @@
+FROM richarvey/nginx-php-fpm:latest
+
+# Install the requirements
+RUN apk update && \
+    apk add postgresql-dev
+
+RUN docker-php-ext-install pdo pdo_pgsql
+
+ENV WEBROOT='/var/userguide/app/userguide'

--- a/docker/userguide/README.md
+++ b/docker/userguide/README.md
@@ -1,0 +1,14 @@
+# Userguide application container
+
+This is a custom container that contains php-apache with pdo and pdo_pgsql
+modules installed.
+
+On the actual instance, it is good to use a persistent volume mounted at
+/var/userguide.
+
+The volume should contain the following:
+ - A checkout of https://github.com/haiku/userguide-translator as /var/userguide/app
+ - A filled config.php at /var/userguide/app/userguide/inc/config.php
+
+To update the userguide tool, execute:
+    `docker exec -it <CONTAINER_ID> git pull /var/userguide/app`

--- a/tools/cert-renew
+++ b/tools/cert-renew
@@ -8,7 +8,7 @@
 # TODO: Test each certificate for validity? If no certs
 # expire soon, don't bring down router container?
 
-DOMAINS="review.haiku-os.org cgit.haiku-os.org dev.haiku-os.org git.haiku-os.org haiku-os.org api.haiku-os.org userguide.haiku-os.org ports-mirror.haiku-os.org dev.haiku-os.org build.haiku-os.org"
+DOMAINS="haiku-os.org api.haiku-os.org build.haiku-os.org cgit.haiku-os.org dev.haiku-os.org git.haiku-os.org i18n.haiku-os.org ports-mirror.haiku-os.org review.haiku-os.org userguide.haiku-os.org"
 LOG="/var/log/letsencrypt.log"
 CONTEXT="/root/infrastructure"
 

--- a/tools/fake-cert
+++ b/tools/fake-cert
@@ -9,7 +9,7 @@
 # To regenerate fakecerts, rm -rf /etc/letsencrypt/live/*
 
 CERT_ROOT="/etc/letsencrypt/live"
-DOMAINS="review.haiku-os.org cgit.haiku-os.org git.haiku-os.org haiku-os.org api.haiku-os.org userguide.haiku-os.org ports-mirror.haiku-os.org dev.haiku-os.org build.haiku-os.org"
+DOMAINS="haiku-os.org api.haiku-os.org build.haiku-os.org cgit.haiku-os.org dev.haiku-os.org git.haiku-os.org i18n.haiku-os.org ports-mirror.haiku-os.org review.haiku-os.org userguide.haiku-os.org"
 mkdir -p $CERT_ROOT
 for i in $DOMAINS; do
 	if [ -d $CERT_ROOT/$i ]; then


### PR DESCRIPTION
combination of fastcgi and nginx.

Notes:
 * I decided that the container will merely contain the elements to
   run the application, but that the application itself is part of the
   persistent storage. This is also mostly due to practical
   considerations, as otherwise the source_docs and export directories
   would need to be linked to a persistent volume. This just feels more
   clean.