### PR TITLE
buildbot: set workdir to . when recreating tooldirs

### DIFF
--- a/data/buildbot/master.cfg
+++ b/data/buildbot/master.cfg
@@ -1084,6 +1084,7 @@ for targetArch in targetArchitectures:
 			description = ['deleting'],
 			descriptionDone = ['deleted'],
 			descriptionSuffix = [targetArch, 'tooldir'],
+			workdir='.',
 			name = 'delete %s tooldir' % targetArch,
 			timeout = 1200))
 	# create empty cross-tools dir
@@ -1093,6 +1094,7 @@ for targetArch in targetArchitectures:
 			description = ['creating'],
 			descriptionDone = ['created'],
 			descriptionSuffix = [targetArch, 'tooldir'],
+			workdir='.',
 			name = 'create %s tooldir' % targetArch))
 	# build cross tools for current architecture
 	buildtoolsFactory.addStep(


### PR DESCRIPTION
otherwise it defaults to 'build'