### PR TITLE
Add "download-commands" plugin

### DIFF
--- a/docker/gerrit/Dockerfile
+++ b/docker/gerrit/Dockerfile
@@ -33,7 +33,7 @@ ENV GERRITFORGE_URL=https://gerrit-ci.gerritforge.com
 ENV GERRITFORGE_ARTIFACT_DIR=lastSuccessfulBuild/artifact/bazel-genfiles/plugins
 
 # Download Plugins
-ENV PLUGINS="delete-project events-log gitiles importer admin-console webhooks"
+ENV PLUGINS="delete-project events-log gitiles importer admin-console webhooks download-commands"
 ENV PLUGIN_VERSION=bazel-stable-2.15
 RUN for i in ${PLUGINS}; do \
 	curl -fSsL ${GERRITFORGE_URL}/job/plugin-$i-${PLUGIN_VERSION}/${GERRITFORGE_ARTIFACT_DIR}/$i/$i.jar \


### PR DESCRIPTION
This provides various commands in the "download" menu to easily checkout
a changeset using git. Could ease things a little for users who
occasionally need to download and test a patch.