### PR TITLE
Add "download-commands" plugin

### DIFF
--- a/docker/gerrit/Dockerfile
+++ b/docker/gerrit/Dockerfile
@@ -8,7 +8,7 @@ ENV GERRIT_SITE ${GERRIT_HOME}/review_site
 ENV GERRIT_WAR ${GERRIT_HOME}/gerrit.war
 ENV GERRIT_VERSION 2.15.1
 ENV GERRIT_USER gerrit2
-ENV GERRIT_INIT_ARGS ""
+ENV GERRIT_INIT_ARGS "--install-plugin=download-comands"
 
 # Add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN adduser -D -h "${GERRIT_HOME}" -g "Gerrit User" -s /sbin/nologin "${GERRIT_USER}"


### PR DESCRIPTION
This provides various commands in the "download" menu to easily checkout
a changeset using git. Could ease things a little for users who
occasionally need to download and test a patch.