### PR TITLE
Updated IPv4 address for tnonline.net

### DIFF
--- a/data/repo-mirror/haiku-repositories/rsync-whitelist
+++ b/data/repo-mirror/haiku-repositories/rsync-whitelist
@@ -10,5 +10,5 @@
 # haiku.datente.com  (@warrenmyers)
 136.243.154.164
 # tnonline.net (mail:at:lechevalier.se)
-155.4.110.233
+81.170.131.138
 2001:470:28:704::1


### PR DESCRIPTION
There is a new IPv4 endpoint for tnonline.net  (mirrors.tnonline.net) (as mentioned already on the haiku-development mailing list. 