### PR TITLE
Traefik: set minimum TLS version to 1.2

### DIFF
--- a/data/traefik/traefik.toml
+++ b/data/traefik/traefik.toml
@@ -20,6 +20,7 @@ filePath = "/logs/access.log"
       # Allows Traefik to pass internal X-Forwarded-* headers
       trustedIPs = ["127.0.0.1/32", "10.0.0.0/8"]
   [entryPoints.https.tls]
+    minVersion = "VersionTLS12"
   [entryPoints.api]
     address = ":9191"
 


### PR DESCRIPTION
Fixes #16350
See: https://doc.traefik.io/traefik/v1.7/configuration/entrypoints/#specify-minimum-tls-version

Will this set it for all traefik endpoints?