### PR TITLE
Concourse: add catkeys task to haiku-release pipeline

### DIFF
--- a/concourse/pipelines/haiku-release.yml
+++ b/concourse/pipelines/haiku-release.yml
@@ -125,6 +125,39 @@ jobs:
                 echo "$S3_ENDPOINT/((bucket_image))/((arch))/${ARTIFACT}.sha256 was successfully uploaded!"
                 mc cp -q ${ARTIFACT}.minisig remote/((bucket_image))/((arch))/
                 echo "$S3_ENDPOINT/((bucket_image))/((arch))/${ARTIFACT}.minisig was successfully uploaded!"
+      - task: catkeys-((branch))-((arch))
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: { repository: haiku/toolchain-worker-((branch)) }
+          inputs:
+            - name: haiku-git
+            - name: generated.((arch))
+          outputs:
+            - name: catkeys.((arch))
+          params:
+            S3_ENDPOINT: ((s3endpoint))
+            S3_KEY: ((s3key))
+            S3_SECRET: ((s3secret))
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                cd generated.((arch))
+                jam -q catkeys
+                cd objects
+                find catalogs/ -name 'en.catkeys' -exec cp --parents -r {} ../../catkeys.x86_64/ \;
+                cd ../../catkeys.((arch))
+                ARTIFACT="haiku-((branch))-((arch))-catkeys.zip"
+                zip -9 -r ${ARTIFACT} catalogs/
+                sha256sum --tag ${ARTIFACT} > ${ARTIFACT}.sha256
+                mc config host add remote $S3_ENDPOINT $S3_KEY $S3_SECRET --api "s3v4"
+                mc cp -q ${ARTIFACT} remote/haiku-translations/
+                echo "$S3_ENDPOINT/haiku-translations/${ARTIFACT} was successfully uploaded!"
+                mc cp -q ${ARTIFACT}.sha256 remote/haiku-translations/
+                echo "$S3_ENDPOINT/haiku-translations/${ARTIFACT}.sha256 was successfully uploaded!"
   - name: repo-((branch))-((arch))
     public: true
     plan:


### PR DESCRIPTION
This task creates the English catalogues for the current checkout, zips them up, and uploads them to the bucket with nightly images.

Currently, these catkeys are built per branch, per architecture. This will incur a slight overhead, as the translation tooling will only use the x86_gcc2h arch, but the size of these files are small so it is acceptable.

Only the latest catkeys build is retained. This gives the advantage of a predictable filename. There also is no need to keep other catkey archives.

Part of:
 * https://github.com/haiku/infrastructure/issues/37
 * https://dev.haiku-os.org/ticket/17530