### PR TITLE
Updated mirror tnonline.net ipv4

### DIFF
--- a/deployments/rsync.yml
+++ b/deployments/rsync.yml
@@ -111,7 +111,7 @@ data:
     # haiku.datente.com  (@warrenmyers)
     136.243.154.164
     # tnonline.net (mail:at:lechevalier.se)
-    158.174.254.104
+    155.4.110.241
     2001:470:28:704::1
     # truenetwork.ru
     94.247.111.11


### PR DESCRIPTION
Hi. The IPv4 has changed for mirrors.tnonline.net
New IP: 155.4.110.241