### PR TITLE
Deployment for Haiku Format Bot

### DIFF
--- a/deployments/haiku-format-bot.yml
+++ b/deployments/haiku-format-bot.yml
@@ -1,0 +1,40 @@
+### Haiku Format Bot
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haiku-format-bot
+  labels:
+    app: haiku-format-bot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: haiku-format-bot
+  template:
+    metadata:
+      labels:
+        app: haiku-format-bot
+    spec:
+      containers:
+      - name: haiku-format-bot
+        image: ghcr.io/haiku/haiku-format-bot:0.2.0
+        command: ["python3"]
+        args: ["-m", "formatchecker.runner", "--daemon", "--submit"]
+        resources:
+          limits:
+            cpu: "0.25"
+            memory: "256Mi"
+          requests:
+            cpu: "0.15"
+            memory: "128Mi"
+        env:
+        - name: GERRIT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: haiku-format-bot
+              key: username
+        - name: GERRIT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: haiku-format-bot
+              key: password


### PR DESCRIPTION
The template is based on various other templates.

The `haiku-format-bot` is intended to run as a deamon that monitors Gerrit, and applies `haiku-format` to new patches. The process is designed to run continuously. There is no user facing frontend (so there is no web server required). The resource limits have been copied from the `irccat.yml` file. The bot is stateless, so there are no volumes. The bot should in theory be able to run with multiple replicas, but there is no point in doing so.

In the early stages, it will be monitored manually to make sure that it keeps running and to iron out issues.