### PR TITLE
Change HDS database backup to produce insert statements

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard-request--haikudepot-dbdump.md
+++ b/.github/ISSUE_TEMPLATE/standard-request--haikudepot-dbdump.md
@@ -33,6 +33,6 @@ Request for a database dump for debugging and testing purposes.
     ```
 5. Dump, compress and encrypt the masked database. _Note: if this is the first time for this requester, make sure to import their public gpg key._
     ```bash
-    kubectl exec -it deployment/postgres -- pg_dump -U postgres haikudepotserver_masked | xz -z | gpg -r <email@recipient.com> --encrypt -o haikudepotserver.sql.xz.gpg
+    kubectl exec -it deployment/postgres -- pg_dump --inserts -U postgres haikudepotserver_masked | xz -z | gpg -r <email@recipient.com> --encrypt -o haikudepotserver.sql.xz.gpg
     ```
 6. Upload the database to a location, and inform the recipient.


### PR DESCRIPTION
At the present time the HDS database dumps are being recovered with an error for some reason;

```
ERROR:  invalid hexadecimal data: odd number of digits
CONTEXT:  COPY pkg_screenshot_image, line 1650, column data: "\x89504e...0000..."
```

This can be avoided by producing a dump that contains SQL `INSERT ...` statements.