### PR TITLE
switch to use the HDS graphics server recently deployed

### DIFF
--- a/deployments/haikudepotserver.yml
+++ b/deployments/haikudepotserver.yml
@@ -26,6 +26,8 @@ spec:
           value: "smtp"
         - name: HDS_AUTHENTICATION_JWS_ISSUER
           value: "haikuinc.hds"
+        - name: HDS_GRAPHICS_SERVER_BASE_URI
+          value: "http://haikudepotserver-server-graphics:8085"
         - name: SPRING_DATASOURCE_URL
           value: "jdbc:postgresql://postgres:5432/haikudepotserver"
         - name: SPRING_DATASOURCE_USERNAME


### PR DESCRIPTION
In a recently [PR](https://github.com/haiku/infrastructure/pull/148/files) there was introduced a new application server which undertakes graphics operations for the HDS application server. This PR will now re-configure HDS so that it uses that server.