### PR TITLE
HDS to use database for storage

### DIFF
--- a/deployments/haikudepotserver.yml
+++ b/deployments/haikudepotserver.yml
@@ -24,8 +24,8 @@ spec:
         env:
         - name: SPRING_MAIL_HOST
           value: "smtp"
-        - name: HDS_MAINTENANCE_ON_SCHEDULE
-          value: "false"
+        - name: HDS_STORAGE_TYPE
+          value: "pg"
         - name: HDS_AUTHENTICATION_JWS_ISSUER
           value: "haikuinc.hds"
         - name: HDS_GRAPHICS_SERVER_BASE_URI


### PR DESCRIPTION
This change will remove the old config item `HDS_MAINTENANCE_ON_SCHEDULE` which is no longer used and flags on
postgres job data storage so that job data is no longer stored in the local overlay-fs of the pod but in the database in a sequence of `BLOB`-s.

A periodic maintenance task will "garbage collect" any stored data which is no longer active.