### PR TITLE
HDS enable db job service

### DIFF
--- a/deployments/haikudepotserver.yml
+++ b/deployments/haikudepotserver.yml
@@ -24,8 +24,8 @@ spec:
         env:
         - name: SPRING_MAIL_HOST
           value: "smtp"
-        - name: HDS_STORAGE_TYPE
-          value: "pg"
+        - name: HDS_JOBSERVICE_TYPE
+          value: "db"
         - name: HDS_AUTHENTICATION_JWS_ISSUER
           value: "haikuinc.hds"
         - name: HDS_GRAPHICS_SERVER_BASE_URI


### PR DESCRIPTION
This PR will remove the older flag env-var `HDS_STORAGE_TYPE` and will now enable the new flag to enable the database-based Job storage system using `HDS_JOBSERVICE_TYPE`. 

After merging this, restart the HDS system.

Next, test the job system;

1. Authenticate as a user
2. Navigate to the reports page
3. Run the "Package icon archive" report
4. Download the resultant report data
5. Unpack the `.tgz` and check it contains images (OK)

Run the following query;

```
SELECT COUNT(id) FROM job.job;
```

This should return > 0 rows to indicate the system is using the database to operate the job system.
