### PR TITLE
HDS shift some config to env-vars

### DIFF
--- a/deployments/haikudepotserver.yml
+++ b/deployments/haikudepotserver.yml
@@ -22,10 +22,14 @@ spec:
       - name: haikudepotserver
         image: ghcr.io/haiku/haikudepotserver:1.0.177
         env:
+        - name: HDS_BASE_URL
+          value: "https://depot.haiku-os.org"
         - name: SPRING_MAIL_HOST
           value: "smtp"
         - name: HDS_JOBSERVICE_TYPE
           value: "db"
+        - name: HDS_IS_PRODUCTION
+          value: "true"
         - name: HDS_AUTHENTICATION_JWS_ISSUER
           value: "haikuinc.hds"
         - name: HDS_GRAPHICS_SERVER_BASE_URI
@@ -47,6 +51,11 @@ spec:
             secretKeyRef:
               name: haikudepotserver-notify
               key: emails
+        - name: HDS_AUTHENTICATION_JWS_SHARED_KEY
+          valueFrom:
+            secretKeyRef:
+              name: haikudepotserver-jws
+              key: shared-key
         resources:
           limits:
             cpu: "1.0"


### PR DESCRIPTION
The situation with configs has been a bit messy in HDS owing to history. There are some defaults in code, some values baked into the build product, some are in an additional config file that is inserted in the Docker image build and some are provided by env-vars.

I am going to be trying to get all of the config variables defined in the build-product config or env-vars to clean this up. This PR brings in a few new env-vars to the `Deployment` in preparation for an upcoming release.

**NOTE** this change assumes the presence of a new secret for the env-var `HDS_AUTHENTICATION_JWS_SHARED_KEY`. You will need to create this secret. The string value should be some arbitrary UUID. This was value was previously re-generated each time HDS started up, but in the future for active:active redundancy (multiple Pods), this value will need to be consistent across Pods.