### PR TITLE
PG backup script; update to allow excluding data for some tables

### DIFF
--- a/deployments/haikudepotserver.yml
+++ b/deployments/haikudepotserver.yml
@@ -210,6 +210,10 @@ spec:
                   secretKeyRef:
                     name: postgres-admin
                     key: password
+              # Some tables' data is transient and so in a recovery situation does not need to be
+              # recovered. To save on backup overhead these tables are skipped.
+              - name: PG_EXCLUDE_TABLE_DATA_TABLES
+                value: "job.job*data,job.job_state,job.job_specification,job.job,datastore.*"
               volumeMounts:
               - name: rclone-config
                 mountPath: /root/.config


### PR DESCRIPTION
Some HDS tables' data are not necessary to backup because the data is ephemeral. By not backing up these tables' data, it is possible to avoid the processing and storage overhead as well as possible confusion in a disaster recovery situation. In this PR, the script `pgsync.sh` is modified to take an env-var `PG_EXCLUDE_TABLE_DATA_TABLES` which can be set to a comma-separated list of table patterns to not backup. The tables' schema (structure) is still backed up though as a recovery would still expect the structures to be in place.

The following HDS tables' data does not need to be backed up;

- `job.job`
- `job.job_specification`
- `job.job_supplied_data`
- `job.job_generated_data`
- `job.job_state`
- `datastore.object_head`
- `datastore.object_part`

In reality, I can't test this from my side, but have performed some basic checks;

Performed a check without excluding tables' data;

- Adjusted the script so that it would only perform the database dump by commenting out portions
- Performed the database dump locally using the script without `PG_EXCLUDE_TABLE_DATA_TABLES` being set
- Hand-modified the resultant dump to restore to a different database name
- Verified that data was present in;
  - `job.job`
  - `datastore.object_head`
  - `haikudepot.pkg`
  - `haikudepot.pkg_version`
  
Performed a check excluding tables' data;

- Kept the adjusted script from above
- set `PG_EXCLUDE_TABLE_DATA_TABLES` to `job.job*data,job.job_state,job.job_specification,job.job,datastore.*`
- Hand-modified the resultant dump to restore to a different database name
- Verified that data was **not** present in;
  - `job.job`
  - `datastore.object_head`
- Verified that data was present in;
  - `haikudepot.pkg`
  - `haikudepot.pkg_version`
  
It would be good to test this change works and to test that it has no adverse effect on the backups for other users of the `pgsync.sh` script such as Discourse and Pootle.
  
After merge of this PR, it will be necessary to build and push a new build of the `pgbackup` container and then to bump the version at points of use such as;

```
...
          containers:
            - name: pgbackup
              image: ghcr.io/haiku/pgbackup:3.0.4
```

This PR is not urgent and nothing is depending on it although I will be adding more tables in the future which I would likewise prefer to keep out of the backup.