### PR TITLE
HDS to 2x replicas

### DIFF
--- a/deployments/haikudepotserver.yml
+++ b/deployments/haikudepotserver.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: haikudepotserver
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: haikudepotserver
@@ -26,8 +26,6 @@ spec:
           value: "https://depot.haiku-os.org"
         - name: SPRING_MAIL_HOST
           value: "smtp"
-        - name: HDS_JOBSERVICE_TYPE
-          value: "db"
         - name: HDS_IS_PRODUCTION
           value: "true"
         - name: HDS_AUTHENTICATION_JWS_ISSUER


### PR DESCRIPTION
HDS should now be able to function as in an active:active redundant deployment. This commit changes the application server to run 2x replicas. This has been tested locally but if there are problems, it should be able to easily switch back to a single replica again.

Also a redundant configuration parameter `HDS_JOBSERVICE_TYPE` is now removed in the same PR.

After merge, please apply to the cluster.