### PR TITLE
hds update env-vars for cayenne based job system

### DIFF
--- a/deployments/haikudepotserver.yml
+++ b/deployments/haikudepotserver.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: haikudepotserver
-        image: ghcr.io/haiku/haikudepotserver:1.0.183
+        image: ghcr.io/haiku/haikudepotserver:1.0.184
         env:
         - name: HDS_JOBSERVICE_TYPE
           value: "db2"
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
         - name: haikudepotserver-server-graphics
-          image: ghcr.io/haiku/haikudepotserver-server-graphics:1.0.183
+          image: ghcr.io/haiku/haikudepotserver-server-graphics:1.0.184
           resources:
             limits:
               cpu: "1.0"


### PR DESCRIPTION
**NOTE** This should be merged after the 1.0.184 HDS deployment is stable; suggest 24h after.

This change will flag in a new version of the job management system that uses the [Apache Cayenne](https://cayenne.apache.org/) ORM instead of Hibernate.